### PR TITLE
Fixup README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# docker-ruby
+# docker-rust
 
 This repository contains the Dockerfile for a Rust image: [jimmycuadra/rust](https://registry.hub.docker.com/u/jimmycuadra/rust/). The image includes `rustc`, `rustdoc`, `cargo`, Git, SSL certificates, and build essentials, so it should be able to run `cargo build` on most projects out of the box. The path `/source` is a volume where you can mount a Cargo project from the host machine.
 


### PR DESCRIPTION
Fixup a copy & paste error in the package name. It's a bit odd to have a `docker-rust` image whose main headline is `docker-ruby` ;-).
